### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -4235,7 +4235,7 @@ ${css}
 
       if (this.hasAttribute("block")) {
         // normalize the tab indents
-        content = content.replace(/\n/, "");
+        content = content.replace(/\n/g, "");
         const tabs = content.match(/\s*/);
         content = content.replace(new RegExp("\n" + tabs, "g"), "\n");
         content = content.trim();


### PR DESCRIPTION
Potential fix for [https://github.com/cmoorad/mostlyrocks/security/code-scanning/7](https://github.com/cmoorad/mostlyrocks/security/code-scanning/7)

To fix the issue, the regular expression `/\n/` used in the `replace` method should be updated to include the `g` (global) flag. This ensures that all occurrences of newline characters in the `content` string are replaced, not just the first one. This change aligns with the likely intention of normalizing all tab indents in the content.

The fix involves modifying line 4238 in the file `assets/js/distillpub/template.v2.js` to use `/\n/g` instead of `/\n/`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
